### PR TITLE
[TITAN-102] - Wrap JSON.parse in try / catch block

### DIFF
--- a/src/hooks/useAtlasEcom.js
+++ b/src/hooks/useAtlasEcom.js
@@ -36,7 +36,12 @@ async function fetchCart(body) {
   }
 
   if (data.cart_data) {
-    data.cart_data = JSON.parse(data.cart_data);
+    try {
+      data.cart_data = JSON.parse(data.cart_data);
+    } catch (e) {
+      console.err(e);
+      console.log('There was an issue retrieving the cart data');
+    }
   }
 
   return data;
@@ -68,7 +73,7 @@ export function AtlasEcomProvider({ children }) {
       router.events.off('routeChangeStart', handleRouteChange);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, []);
+  }, [router.events]);
 
   async function addToCart(lineItems) {
     const data = await fetchCart({ action: 'add', line_items: lineItems });


### PR DESCRIPTION
- When cart data is received from the fetch request, we reassign it as a parsed object before setting state. 
- Wrapping this parse action in a try / catch block 
- Also adding a dependancy to the `useEffect` which was suggested by TypeScript 

Responding to suggestions made here: https://github.com/wpengine/atlas-commerce-blueprint/issues/6 