### PR TITLE
[TITAN-103] - Preview pages for product ctp and shop page are missing

### DIFF
--- a/src/pages/preview.js
+++ b/src/pages/preview.js
@@ -2,10 +2,18 @@ import { client } from 'client';
 
 import { PostComponent } from './posts/[postSlug]';
 import { PageComponent } from './[...pageUri]';
+import { ProductComponent } from './product/[productSlug]';
+import { ShopComponent } from './shop';
 
 export default function Preview() {
   const isLoading = client.useIsLoading();
   const { typeName, node } = client.auth.usePreviewNode();
+
+  const products = client.useQuery().products({ first: 100 });
+  const product = client.useQuery().product({
+    id: node !== undefined ? node.productSlug : null,
+    idType: 'SLUG',
+  });
 
   if (isLoading || node === undefined) {
     return <p>Loading...</p>;
@@ -18,6 +26,12 @@ export default function Preview() {
   switch (typeName) {
     case 'Page': {
       const page = node;
+
+      if (page.slug === 'shop') {
+        // Will not work with an autosave version of the shop page as the slug changes
+        return <ShopComponent products={products?.nodes} />;
+      }
+
       return <PageComponent page={page} />;
     }
     case 'Post': {
@@ -25,6 +39,10 @@ export default function Preview() {
       return <PostComponent post={post} />;
     }
     // Add custom post types here as needed
+    case 'Product': {
+      return <ProductComponent product={product} />;
+    }
+
     default: {
       throw new Error(`Unknown post type: ${typeName}`);
     }


### PR DESCRIPTION
## Description

- If the shop page is the one being previewed, then render the `ShopComponent` with the queried products
^ If there is an autosave version of this page being previewed it will not work, as the slug changes to an autosave signature 
 - Added the `Product` custom post type to `preview.js` (Although we have purposely hidden the product ACM pages from being accessed via WP Admin menu, previewing is supported if they manually get there)
 
 Addresses a suggestion in this issue: https://github.com/wpengine/atlas-commerce-blueprint/issues/6

## Testing 

Previewing the `Shop` page

https://www.loom.com/share/55c0a5305d5e482a9f2d9ce1357b9db5 

Previewing the `Product` post type 

https://www.loom.com/share/05cc89f2189e41a989ac7c978e135394 