### PR TITLE
[TITAN-104] - Product category menus are hardcoded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .next
 .env
+.DS_Store

--- a/src/components/BreadCrumbsMenu/BreadCrumbsMenu.js
+++ b/src/components/BreadCrumbsMenu/BreadCrumbsMenu.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { classNames } from 'utils';
+import styles from './BreadCrumbsMenu.module.scss';
+
+const BreadCrumbsMenu = ({ path, label, title }) => {
+  return (
+    <nav className={styles.breadcrumbsContainer}>
+      <ul className={styles.breadcrumbs}>
+        <li className={styles.breadcrumb}>
+          <a href='/'>
+            <span>Home</span>
+          </a>
+        </li>
+        <li className={styles.breadcrumb}>
+          <a href={path}>
+            <span>{label}</span>
+          </a>
+        </li>
+        <li className={classNames([styles.breadcrumb, styles.isActive])}>
+          <span>{title}</span>
+        </li>
+      </ul>
+    </nav>
+  );
+};
+
+export default BreadCrumbsMenu;

--- a/src/components/BreadCrumbsMenu/BreadCrumbsMenu.module.scss
+++ b/src/components/BreadCrumbsMenu/BreadCrumbsMenu.module.scss
@@ -1,0 +1,28 @@
+.breadcrumbsContainer {
+  max-width: 80rem;
+  overflow: hidden;
+  padding: 0;
+  li:not(:last-child) {
+    &:after {
+      position: relative;
+      margin: 0 0.5rem;
+      opacity: 1;
+      content: '>';
+      color: #101010;
+    }
+  }
+  .breadcrumbs {
+    margin: 2.5rem 0;
+    list-style: none;
+    .breadcrumb {
+      float: left;
+      cursor: default;
+      &.isActive {
+        font-weight: 700;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+}

--- a/src/components/BreadCrumbsMenu/index.js
+++ b/src/components/BreadCrumbsMenu/index.js
@@ -1,0 +1,3 @@
+import BreadCrumbsMenu from './BreadCrumbsMenu';
+
+export default BreadCrumbsMenu;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -22,6 +22,7 @@ import SkipNavigationLink from './SkipNavigationLink';
 import TaxonomyTerms from './TaxonomyTerms';
 import ProductSummary from './ProductSummary';
 import ProductSort from './ProductSort';
+import BreadCrumbsMenu from './BreadCrumbsMenu';
 
 export {
   Button,
@@ -48,4 +49,5 @@ export {
   TaxonomyTerms,
   ProductSummary,
   ProductSort,
+  BreadCrumbsMenu,
 };

--- a/src/pages/product-category/[categorySlug].js
+++ b/src/pages/product-category/[categorySlug].js
@@ -7,6 +7,7 @@ import {
   Main,
   SEO,
   ProductSort,
+  BreadCrumbsMenu,
 } from 'components';
 import styles from 'styles/pages/_Shop.module.scss';
 import { pageTitle } from 'utils';
@@ -38,28 +39,11 @@ export function ShopComponent({ productCategory }) {
           <section className={styles.bannerHero}>
             <div className='hero-content-container row'>
               <div className={classNames(['column', styles.heroContent])}>
-                <nav className={styles.breadcrumbsContainer}>
-                  <ul className={styles.breadcrumbs}>
-                    <li className={styles.breadcrumb}>
-                      <a href='/'>
-                        <span>Home</span>
-                      </a>
-                    </li>
-                    <li className={styles.breadcrumb}>
-                      <a href='/product-category/'>
-                        <span>Product Category</span>
-                      </a>
-                    </li>
-                    <li
-                      className={classNames([
-                        styles.breadcrumb,
-                        styles.isActive,
-                      ])}
-                    >
-                      <span>{productCategory?.name}</span>
-                    </li>
-                  </ul>
-                </nav>
+                <BreadCrumbsMenu
+                  path='/product-category/'
+                  label='Product Category'
+                  title={productCategory?.name}
+                />
                 <h1 className='section-header'>{productCategory?.name}</h1>
                 <div
                   className='category-description'

--- a/src/styles/pages/_Shop.module.scss
+++ b/src/styles/pages/_Shop.module.scss
@@ -8,34 +8,6 @@
     @media screen and (max-width: 1023px) {
       width: 100%;
     }
-    .breadcrumbsContainer {
-      max-width: 80rem;
-      overflow: hidden;
-      padding: 0;
-      li:not(:last-child) {
-        &:after {
-          position: relative;
-          margin: 0 .5rem;
-          opacity: 1;
-          content: ">";
-          color: #101010;
-        }
-      }
-      .breadcrumbs {
-        margin: 2.5rem 0;
-        list-style: none;
-        .breadcrumb {
-          float: left;
-          cursor: default;
-          &.isActive {
-            font-weight: 700;
-          }
-          a:hover {
-            text-decoration: underline;
-          }
-        }
-      }
-    }
   }
   .heroImage {
     width: 50%;
@@ -60,7 +32,7 @@
       color: #43454b;
       padding: 0.202em 0.6180469716em;
       margin: 10px;
-      font-size: .875em;
+      font-size: 0.875em;
       text-transform: uppercase;
       font-weight: 600;
       display: inline-block;
@@ -105,7 +77,7 @@
           padding: 1rem;
           display: inline-block;
           color: #fff;
-          transition: all .5s;
+          transition: all 0.5s;
           &:hover {
             background-color: #00664e;
           }


### PR DESCRIPTION
Addresses suggestion in the following : https://github.com/wpengine/atlas-commerce-blueprint/issues/6 

This was intentional to be hardcoded as its the only place that it is used and is simply just a breadcrumb indicator of the current category location in reference to the home page. It does not read categories from WordPress. 

I broke it out into it's own component for the time being, it doesn't do much except accept the content as props but perhaps will be extended later to be used as more general breadcrumbs. 