### PR TITLE
[TITAN-107] - Extract Product-meta element on its own Component

### DIFF
--- a/src/components/ProductFormField/index.js
+++ b/src/components/ProductFormField/index.js
@@ -1,0 +1,2 @@
+import ProductFormField from './ProductFormField';
+export default ProductFormField;

--- a/src/components/ProductMeta/ProductMeta.js
+++ b/src/components/ProductMeta/ProductMeta.js
@@ -1,0 +1,100 @@
+import React from 'react';
+import { ProductFormField, Button } from 'components';
+import Link from 'next/link';
+import styles from './ProductMeta.module.scss';
+
+const ProductMeta = ({
+  product,
+  sortedFormFields,
+  handleChange,
+  handleSubmit,
+  handleFieldChange,
+  variantProduct,
+  values,
+}) => {
+  const inventoryTracking = product.inventoryTracking;
+  let inventoryLevel = product.inventoryLevel;
+
+  if (inventoryTracking === 'variant' && variantProduct) {
+    inventoryLevel = variantProduct.inventory;
+  } else if (inventoryTracking === 'none') {
+    inventoryLevel = null;
+  }
+
+  let purchaseDisabled =
+    variantProduct?.purchasing_disabled || inventoryLevel === 0;
+
+  const displayProduct = variantProduct ?? product;
+  const productBrand = product.brand?.node;
+  const productCategories = product.productCategories().nodes;
+
+  let purchaseDisabledMessage =
+    'The selected product combination is currently unavailable.';
+
+  return (
+    <div className='product_meta'>
+      <p>SKU: {displayProduct?.sku}</p>
+
+      {productCategories?.length ? (
+        <p>
+          Categories:{' '}
+          {product.productCategories().nodes.map((category, index) => (
+            <span key={category.id}>
+              {index === 0 ? '' : ', '}
+              <Link
+                href={`/product-category/${category.slug}`}
+                key={category.id}
+              >
+                <a>{category.name}</a>
+              </Link>
+            </span>
+          ))}
+        </p>
+      ) : null}
+
+      {productBrand ? <p>Brand: {productBrand.name}</p> : null}
+
+      <form onSubmit={handleSubmit}>
+        {sortedFormFields.map((field) => (
+          <ProductFormField
+            field={field}
+            value={values[`${field.prodOptionType}[${field.id}]`]}
+            onChange={handleFieldChange}
+            key={field.id}
+          />
+        ))}
+
+        <div>
+          <label style={{ display: 'block' }}>Quantity:</label>
+          <input
+            type='number'
+            min='1'
+            max={inventoryLevel}
+            step='1'
+            name='quantity'
+            value={values.quantity}
+            onChange={handleChange}
+            disabled={purchaseDisabled}
+            className={styles.quantity}
+          />
+        </div>
+
+        {purchaseDisabled ? (
+          <div className={styles.purchaseDisabled}>
+            {purchaseDisabledMessage}
+          </div>
+        ) : null}
+
+        <Button
+          styleType='secondary'
+          className={styles.addToCart}
+          disabled={purchaseDisabled}
+        >
+          Add to cart
+        </Button>
+      </form>
+    </div>
+  );
+};
+
+export default ProductMeta;

--- a/src/components/ProductMeta/ProductMeta.module.scss
+++ b/src/components/ProductMeta/ProductMeta.module.scss
@@ -1,0 +1,21 @@
+.purchaseDisabled {
+  margin: 1em 0;
+  padding: 0.5em 1em;
+  background: #ddd;
+}
+
+.addToCart:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+input.quantity {
+  width: 5em;
+  padding: 0.25em;
+  border-radius: 4px;
+  border-width: 1px;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+}

--- a/src/components/ProductMeta/index.js
+++ b/src/components/ProductMeta/index.js
@@ -1,0 +1,2 @@
+import ProductMeta from './ProductMeta';
+export default ProductMeta;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -22,6 +22,8 @@ import SkipNavigationLink from './SkipNavigationLink';
 import TaxonomyTerms from './TaxonomyTerms';
 import ProductSummary from './ProductSummary';
 import ProductSort from './ProductSort';
+import ProductFormField from './ProductFormField';
+import ProductMeta from './ProductMeta';
 
 export {
   Button,
@@ -48,4 +50,6 @@ export {
   TaxonomyTerms,
   ProductSummary,
   ProductSort,
+  ProductFormField,
+  ProductMeta,
 };

--- a/src/pages/product/[productSlug].js
+++ b/src/pages/product/[productSlug].js
@@ -6,10 +6,9 @@ import {
   Notification,
   Main,
   SEO,
-  Button,
   ProductSummary,
+  ProductMeta,
 } from 'components';
-import ProductFormField from 'components/ProductFormField/ProductFormField';
 
 import styles from 'styles/pages/_Product.module.scss';
 import 'slick-carousel/slick/slick.css';
@@ -18,7 +17,6 @@ import 'slick-carousel/slick/slick-theme.css';
 import { pageTitle } from 'utils';
 
 import { useRouter } from 'next/router';
-import Link from 'next/link';
 
 import { useState, useMemo } from 'react';
 import Slider from 'react-slick';
@@ -94,16 +92,6 @@ export function ProductComponent({ product }) {
     .join(';');
 
   const variantProduct = variantLookup[variantLookupId];
-  const displayProduct = variantProduct ?? product;
-
-  const inventoryTracking = product.inventoryTracking;
-  let inventoryLevel = product.inventoryLevel;
-
-  if (inventoryTracking === 'variant' && variantProduct) {
-    inventoryLevel = variantProduct.inventory;
-  } else if (inventoryTracking === 'none') {
-    inventoryLevel = null;
-  }
 
   if (variantProduct?.img) {
     productImages = [
@@ -115,11 +103,7 @@ export function ProductComponent({ product }) {
     ].concat(productImages.slice(1));
   }
 
-  let purchaseDisabled =
-    variantProduct?.purchasing_disabled || inventoryLevel === 0;
   let priceAdjuster = 0;
-  let purchaseDisabledMessage =
-    'The selected product combination is currently unavailable.';
 
   valuesKeys.forEach((key) => {
     let match;
@@ -267,70 +251,17 @@ export function ProductComponent({ product }) {
 
               <p dangerouslySetInnerHTML={{ __html: product?.description }} />
 
-              <div className='product_meta'>
-                <p>SKU: {displayProduct.sku}</p>
-
-                {productCategories?.length ? (
-                  <p>
-                    Categories:{' '}
-                    {product
-                      .productCategories()
-                      .nodes.map((category, index) => (
-                        <span key={category.id}>
-                          {index === 0 ? '' : ', '}
-                          <Link
-                            href={`/product-category/${category.slug}`}
-                            key={category.id}
-                          >
-                            <a>{category.name}</a>
-                          </Link>
-                        </span>
-                      ))}
-                  </p>
-                ) : null}
-
-                {productBrand ? <p>Brand: {productBrand.name}</p> : null}
-
-                <form onSubmit={handleSubmit}>
-                  {sortedFormFields.map((field) => (
-                    <ProductFormField
-                      field={field}
-                      value={values[`${field.prodOptionType}[${field.id}]`]}
-                      onChange={handleFieldChange}
-                      key={field.id}
-                    />
-                  ))}
-
-                  <div>
-                    <label style={{ display: 'block' }}>Quantity:</label>
-                    <input
-                      type='number'
-                      min='1'
-                      max={inventoryLevel}
-                      step='1'
-                      name='quantity'
-                      value={values.quantity}
-                      onChange={handleChange}
-                      disabled={purchaseDisabled}
-                      className={styles.quantity}
-                    />
-                  </div>
-
-                  {purchaseDisabled ? (
-                    <div className={styles.purchaseDisabled}>
-                      {purchaseDisabledMessage}
-                    </div>
-                  ) : null}
-
-                  <Button
-                    styleType='secondary'
-                    className={styles.addToCart}
-                    disabled={purchaseDisabled}
-                  >
-                    Add to cart
-                  </Button>
-                </form>
-              </div>
+              <ProductMeta
+                productCategories={productCategories}
+                productBrand={productBrand}
+                sortedFormFields={sortedFormFields}
+                handleChange={handleChange}
+                handleSubmit={handleSubmit}
+                handleFieldChange={handleFieldChange}
+                variantProduct={variantProduct}
+                values={values}
+                product={product}
+              />
             </div>
           </div>
         </div>

--- a/src/pages/product/[productSlug].js
+++ b/src/pages/product/[productSlug].js
@@ -31,9 +31,6 @@ export function ProductComponent({ product }) {
   const generalSettings = useQuery().generalSettings;
   const storeSettings = useQuery().storeSettings({ first: 1 })?.nodes?.[0];
 
-  const productCategories = product.productCategories().nodes;
-  const productBrand = product.brand?.node;
-
   const relatedProductIds = JSON.parse(product.relatedProducts ?? '[]');
   const relatedProducts = useQuery().products({
     where: { bigCommerceIDIn: relatedProductIds },
@@ -42,8 +39,6 @@ export function ProductComponent({ product }) {
   const productFormFields = JSON.parse(product.productFormFieldsJson ?? '[]');
   const variantLookup = JSON.parse(product.variantLookupJson ?? '{}');
   const modifierLookup = JSON.parse(product.modifierLookupJson ?? '{}');
-
-  // console.log({ productFormFields, variantLookup, modifierLookup });
 
   const productName = product.name;
   const bigCommerceId = product.bigCommerceID;
@@ -129,8 +124,6 @@ export function ProductComponent({ product }) {
     (variantProduct?.calculatedPrice ?? product.calculatedPrice) +
     priceAdjuster;
 
-  // console.log({ values, variantProduct, inventoryLevel });
-
   function handleChange(event) {
     setValues((prevValues) => ({
       ...prevValues,
@@ -179,8 +172,6 @@ export function ProductComponent({ product }) {
         modifiers: modifierOptionValues,
       },
     ]).then((data) => {
-      // console.log({ 'addToCart()': data });
-
       setProductNotification(
         data.status === 200
           ? { message: `"${productName}" has been added to your cart.` }
@@ -252,15 +243,13 @@ export function ProductComponent({ product }) {
               <p dangerouslySetInnerHTML={{ __html: product?.description }} />
 
               <ProductMeta
-                productCategories={productCategories}
-                productBrand={productBrand}
+                product={product}
                 sortedFormFields={sortedFormFields}
                 handleChange={handleChange}
                 handleSubmit={handleSubmit}
                 handleFieldChange={handleFieldChange}
                 variantProduct={variantProduct}
                 values={values}
-                product={product}
               />
             </div>
           </div>

--- a/src/styles/pages/_Product.module.scss
+++ b/src/styles/pages/_Product.module.scss
@@ -8,15 +8,17 @@
     @media (min-width: $breakpoint-small) {
       margin-right: 2.5rem;
     }
-  
+
     :global {
-      .slick-prev, .slick-next {
-        &, &:before {
+      .slick-prev,
+      .slick-next {
+        &,
+        &:before {
           color: #000;
         }
       }
     }
-    
+
     .productGalleryThumbnail {
       cursor: pointer;
     }
@@ -32,7 +34,7 @@
     border-color: #43454b;
     color: #43454b;
     padding: 0.202em 0.6180469716em;
-    font-size: .875em;
+    font-size: 0.875em;
     text-transform: uppercase;
     font-weight: 600;
     display: inline-block;
@@ -43,48 +45,26 @@
   img {
     max-width: initial;
   }
-  
+
   .notification {
     display: flex;
     margin: 2.5em 0;
     padding: 1em 2em 1em 3.5em;
-    border-left: .75em solid rgba(0, 0, 0, .15);
+    border-left: 0.75em solid rgba(0, 0, 0, 0.15);
     color: #fff;
     background: #0f834d;
-    
+
     .message {
       margin-right: auto;
     }
-    
+
     a {
       color: inherit;
       text-decoration: underline;
     }
   }
-  
+
   .notificationError {
     background-color: #c00;
-  }
-  
-  .addToCart:disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-  
-  input.quantity {
-    width: 5em;
-    padding: .25em;
-    border-radius: 4px;
-    border-width: 1px;
-    
-    &:disabled {
-      cursor: not-allowed;
-    }
-  }
-  
-  .purchaseDisabled {
-    margin: 1em 0;
-    padding: .5em 1em;
-    background: #ddd;
   }
 }


### PR DESCRIPTION
### Description

- Also moving the props that it needs and the styles from the parent into its own `scss` module
- Addresses suggestion in: https://github.com/wpengine/atlas-commerce-blueprint/issues/6

### Testing

Tested that adding product with various variants included in this meta still works as expected 