### PR TITLE
[TITAN-91] - Make Blueprint responsive on all devices

### DIFF
--- a/src/components/ContentWrapper/ContentWrapper.new.module.scss
+++ b/src/components/ContentWrapper/ContentWrapper.new.module.scss
@@ -2,41 +2,55 @@
 
 .content {
   :global {
+    .wp-block-atlas-commerce-blocks-hero {
+      #atlas-commerce-blocks-hero {
+        .gb-layout-column-wrap {
+          max-width: 1200px;
+          width: 66%;
+
+          @media (max-width: $breakpoint-extra-small) {
+            max-width: 100%;
+            width: 100%;
+          }
+        }
+      }
+    }
+
     .wc-block-grid {
       width: percentage(10/12);
       margin-left: auto;
       margin-right: auto;
       margin-bottom: 8%;
-      
+
       .wc-block-grid__products {
         display: flex;
         flex-wrap: wrap;
         height: auto !important;
-      
+
         ._wc-block-grid__product {
           width: 100% !important;
           height: auto !important;
           padding: 20px;
-          
+
           @media (min-width: 768px) {
             width: 50% !important;
           }
-          
+
           @media (min-width: 992px) {
             width: 33.33% !important;
           }
-          
+
           .price {
-            padding: .75em 0;
+            padding: 0.75em 0;
           }
         }
       }
     }
-    
+
     .wp-block-column {
       padding: 0 1em;
     }
-    
+
     // Very temporary!
     .gb-block-layout-column-inner {
       > h2:first-child {

--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -17,6 +17,10 @@
   width: 400px;
   height: auto;
   margin: 0.8rem 0;
+
+  @media (max-width: $breakpoint-extra-small) {
+    width: 50%;
+  }
 }
 
 .logo h3 {
@@ -72,6 +76,10 @@
 
   @media (min-width: $breakpoint-small) {
     display: none;
+  }
+
+  @media (max-width: $breakpoint-extra-small) {
+    height: 50px;
   }
 }
 
@@ -261,5 +269,9 @@
         }
       }
     }
+  }
+
+  @media (max-width: $breakpoint-extra-small) {
+    width: 100%;
   }
 }

--- a/src/styles/_Grid.scss
+++ b/src/styles/_Grid.scss
@@ -131,6 +131,11 @@
     &.column-25 {
       flex: 0 0 25%;
       max-width: 25%;
+
+      @media (max-width: $breakpoint-extra-small) {
+        flex: 0 0 100%;
+        max-width: 100%;
+      }
     }
 
     &.column-33,
@@ -142,6 +147,11 @@
     &.column-40 {
       flex: 0 0 40%;
       max-width: 40%;
+
+      @media (max-width: $breakpoint-extra-small) {
+        flex: 0 0 100%;
+        max-width: 100%;
+      }
     }
 
     &.column-50 {

--- a/src/styles/_Grid.scss
+++ b/src/styles/_Grid.scss
@@ -6,13 +6,16 @@
 .container {
   margin: 0 auto;
   max-width: $container-max-width;
-//   padding: 0 2rem;
   padding: 0 0;
   position: relative;
   width: 100%;
 
   &.small {
     max-width: $content-max-width;
+  }
+
+  @media (max-width: $breakpoint-medium) {
+    padding: 1.5rem;
   }
 }
 


### PR DESCRIPTION
### Description 

Added responsive CSS to the following elements so that they appear cleanly on mobile and tablet: 

- The header with the logo, hamburger menu and cart elements 
- The product listings: added media queries for the grid columns in use 
- The hero block: this depends on a change [in this PR](https://github.com/wpengine/atlas-commerce-blocks/pull/5) 

## Testing 

Tested using browser dev tools 

### Desktop 

<img width="1752" alt="Screenshot 2022-10-13 at 12 11 34" src="https://user-images.githubusercontent.com/48026075/195581752-d8b76cc2-6f28-45f6-8cb2-15c931a789fd.png">

### Tablet 

<img width="844" alt="Screenshot 2022-10-13 at 12 14 51" src="https://user-images.githubusercontent.com/48026075/195582438-4d0494ef-aed7-479d-9724-2a122401e024.png">

<img width="868" alt="Screenshot 2022-10-13 at 12 14 43" src="https://user-images.githubusercontent.com/48026075/195582433-a839ba9d-d9ad-42a2-aa72-1687713677c8.png">

### Mobile

 
<img width="418" alt="Screenshot 2022-10-13 at 12 12 46" src="https://user-images.githubusercontent.com/48026075/195582497-375a5bb4-17b3-431b-bdfc-acf36604ac5d.png">
<img width="383" alt="Screenshot 2022-10-13 at 12 13 18" src="https://user-images.githubusercontent.com/48026075/195582501-06080336-014d-4343-a632-c8ea0fdeb90f.png">
<img width="467" alt="Screenshot 2022-10-13 at 12 14 20" src="https://user-images.githubusercontent.com/48026075/195582505-ad976b08-02e8-4c0a-b9e2-017417663763.png">

