### PR TITLE
[TITAN-105] - Values calculation should be extracted on a service

### DIFF
--- a/src/components/ProductMeta/ProductMeta.js
+++ b/src/components/ProductMeta/ProductMeta.js
@@ -3,32 +3,45 @@ import { ProductFormField, Button } from 'components';
 import Link from 'next/link';
 import styles from './ProductMeta.module.scss';
 
+import { checkPurchaseDisabled } from '../../helpers/productHelpers.js';
+
 const ProductMeta = ({
   product,
   sortedFormFields,
   handleChange,
   handleSubmit,
   handleFieldChange,
-  variantProduct,
-  values,
+  productVariant,
+  variantOrModFields,
+  variantValueKeys,
+  modifierLookup,
 }) => {
   const inventoryTracking = product.inventoryTracking;
   let inventoryLevel = product.inventoryLevel;
 
-  if (inventoryTracking === 'variant' && variantProduct) {
-    inventoryLevel = variantProduct.inventory;
+  if (inventoryTracking === 'variant' && productVariant) {
+    inventoryLevel = productVariant.inventory;
   } else if (inventoryTracking === 'none') {
     inventoryLevel = null;
   }
 
-  let purchaseDisabled =
-    variantProduct?.purchasing_disabled || inventoryLevel === 0;
+  const modifierPurchaseDisabled = checkPurchaseDisabled(
+    variantValueKeys,
+    variantOrModFields,
+    modifierLookup
+  );
 
-  const displayProduct = variantProduct ?? product;
+  let purchaseDisabled =
+    modifierPurchaseDisabled.purchaseDisabled ||
+    productVariant?.purchasing_disabled ||
+    inventoryLevel === 0;
+
+  const displayProduct = productVariant ?? product;
   const productBrand = product.brand?.node;
   const productCategories = product.productCategories().nodes;
 
   let purchaseDisabledMessage =
+    modifierPurchaseDisabled.purchaseDisabledMessage ||
     'The selected product combination is currently unavailable.';
 
   return (
@@ -58,7 +71,7 @@ const ProductMeta = ({
         {sortedFormFields.map((field) => (
           <ProductFormField
             field={field}
-            value={values[`${field.prodOptionType}[${field.id}]`]}
+            value={variantOrModFields[`${field.prodOptionType}[${field.id}]`]}
             onChange={handleFieldChange}
             key={field.id}
           />
@@ -72,7 +85,7 @@ const ProductMeta = ({
             max={inventoryLevel}
             step='1'
             name='quantity'
-            value={values.quantity}
+            value={variantOrModFields.quantity}
             onChange={handleChange}
             disabled={purchaseDisabled}
             className={styles.quantity}

--- a/src/helpers/productHelpers.js
+++ b/src/helpers/productHelpers.js
@@ -1,3 +1,7 @@
+/**
+ * Checks the JSON provided from BigCommerce for the Variant and Modification options.
+ * @returns An Object containing either variant[id] or modification[id] keys and their values.
+ */
 export function computeVariantOrModificationFormFields(productFormFields) {
   const variantOrModFields = productFormFields.reduce(
     (acc, variantOrModField) => {
@@ -19,6 +23,10 @@ export function computeVariantOrModificationFormFields(productFormFields) {
   };
 }
 
+/**
+ * Checks the product variant lookup with the formatted variant and id combonation selected and returns the information about that variant to be rendered.
+ * @returns An Object containing the new product information with the variant selected.
+ */
 export function lookupProductVariants(
   variantValueKeys,
   variantLookup,
@@ -38,6 +46,10 @@ export function lookupProductVariants(
   return variantLookup[variantLookupId];
 }
 
+/**
+ * Checks for the price adjusted after applying modifications.
+ * @returns The adjusted price to be used in price calculations.
+ */
 export function checkPriceAdjuster(variantValueKeys, modifierLookup) {
   let priceAdjuster = 0;
 
@@ -55,6 +67,10 @@ export function checkPriceAdjuster(variantValueKeys, modifierLookup) {
   return priceAdjuster;
 }
 
+/**
+ * Checks if the purchase is disabled and its message after applying modifications.
+ * @returns An Object containing wether the purchase is disabled and the corresponding message after applying modifications.
+ */
 export function checkPurchaseDisabled(
   variantValueKeys,
   variantOrModFields,

--- a/src/helpers/productHelpers.js
+++ b/src/helpers/productHelpers.js
@@ -1,0 +1,84 @@
+export function computeVariantOrModificationFormFields(productFormFields) {
+  const variantOrModFields = productFormFields.reduce(
+    (acc, variantOrModField) => {
+      acc[`${variantOrModField.prodOptionType}[${variantOrModField.id}]`] =
+        variantOrModField.option_values?.reduce((defaultValue, option) => {
+          if (option.is_default) {
+            return option.id;
+          }
+          return defaultValue;
+        }, null) ?? variantOrModField.config?.default_value;
+      return acc;
+    },
+    {}
+  );
+
+  return {
+    ...variantOrModFields,
+    quantity: 1,
+  };
+}
+
+export function lookupProductVariants(
+  variantValueKeys,
+  variantLookup,
+  variantOrModFields
+) {
+  const variantLookupId = variantValueKeys
+    .reduce((acc, key) => {
+      let match;
+      if ((match = key.match(/^variant\[(.*)\]$/))) {
+        acc.push(match[1] + '.' + variantOrModFields[key]);
+      }
+      return acc;
+    }, [])
+    .sort()
+    .join(';');
+
+  return variantLookup[variantLookupId];
+}
+
+export function checkPriceAdjuster(variantValueKeys, modifierLookup) {
+  let priceAdjuster = 0;
+
+  variantValueKeys.forEach((key) => {
+    let match;
+    if ((match = key.match(/^modifier\[(.*)\]$/))) {
+      const modifierLookupId = match[1] + '.' + variantValueKeys[key];
+      const modifier = modifierLookup[modifierLookupId];
+      if (modifier) {
+        priceAdjuster += modifier.price_adjuster;
+      }
+    }
+  });
+
+  return priceAdjuster;
+}
+
+export function checkPurchaseDisabled(
+  variantValueKeys,
+  variantOrModFields,
+  modifierLookup
+) {
+  let purchaseDisabled = false;
+  let purchaseDisabledMessage = null;
+
+  variantValueKeys.forEach((key) => {
+    let match;
+    if ((match = key.match(/^modifier\[(.*)\]$/))) {
+      const modifierLookupId = match[1] + '.' + variantOrModFields[key];
+      const modifier = modifierLookup[modifierLookupId];
+      if (modifier) {
+        if (modifier.purchasing_disabled?.status === true) {
+          purchaseDisabled = true;
+
+          if (modifier.purchasing_disabled.message) {
+            purchaseDisabledMessage = modifier.purchasing_disabled.message;
+          }
+        }
+      }
+    }
+  });
+
+  return { purchaseDisabled, purchaseDisabledMessage };
+}


### PR DESCRIPTION
### Description
Moving some complex logic to do with variants and modifiers to a helpers library that deals with this. 
Addresses suggestion in this issue: https://github.com/wpengine/atlas-commerce-blueprint/issues/6 

There are now 3 helper functions: 

- Checks the JSON provided from BigCommerce for the Variant and Modification options that are to be rendered in the form that allow user to select these options or modifications. 
- Checks the variant or modification lookup map provided by BigCommerce with the one selected by the user and then returns the information to be re-rendered by the `ProductComponent`. 
- Checks for the price adjusted after applying modifications.
- Checks if the purchase is disabled and its message after applying modifications. 

The `ProductMeta` component was refactored to receive props it needed to fulfill the helper functions parameter requirements. 
Used comments as documentation for these helper functions. 

### Testing 

Re-tested all cart values and state on both our site and BigCommerce after applying variants. 
(Modifications don't exist on any of products)

[More on Variants and Modifiers in BigCommerce](https://support.bigcommerce.com/s/article/Variants-and-Modifiers?language=en_US)