### PR TITLE
[TITAN-121] - Create Headless Cart 

### DIFF
--- a/src/components/Cart/CartTable.js
+++ b/src/components/Cart/CartTable.js
@@ -1,13 +1,31 @@
 import React from 'react';
+import { AiOutlineCloseCircle } from 'react-icons/ai';
 import styles from './CartTable.module.scss';
+import useAtlasEcom from '@hooks/useAtlasEcom';
 
-const CartTable = ({ cartItems }) => {
+const CartTable = ({ cartItems, setProductNotification }) => {
+  const { removeFromCart } = useAtlasEcom();
+
+  const handleClick = (itemId) => {
+    removeFromCart(itemId).then((data) =>
+      setProductNotification(
+        data.message
+          ? { message: data.message }
+          : {
+              message: 'There was an error removing this item from your cart',
+              className: 'notificationError',
+            }
+      )
+    );
+  };
+
   return (
     <div className={styles.cartTable}>
       <table>
         <thead>
           <tr>
             <th className={styles.hideOnMobile}></th>
+            <th></th>
             <th>Product</th>
             <th>Price</th>
             <th className={styles.hideOnMobile}>Quantity</th>
@@ -17,6 +35,12 @@ const CartTable = ({ cartItems }) => {
         <tbody>
           {cartItems.map((item, index) => (
             <tr key={`cart-item-${index}`}>
+              <td>
+                <AiOutlineCloseCircle
+                  style={{ 'cursor': 'pointer' }}
+                  onClick={() => handleClick(item.id)}
+                />
+              </td>
               <td className={styles.hideOnMobile}>
                 <img
                   src={item.image_url}

--- a/src/components/Cart/CartTable.js
+++ b/src/components/Cart/CartTable.js
@@ -7,17 +7,17 @@ const CartTable = ({ cartItems }) => {
       <table>
         <thead>
           <tr>
-            <th></th>
+            <th className={styles.hideOnMobile}></th>
             <th>Product</th>
             <th>Price</th>
-            <th>Quantity</th>
-            <th>Subtotal</th>
+            <th className={styles.hideOnMobile}>Quantity</th>
+            <th className={styles.hideOnMobile}>Subtotal</th>
           </tr>
         </thead>
         <tbody>
           {cartItems.map((item, index) => (
             <tr key={`cart-item-${index}`}>
-              <td>
+              <td className={styles.hideOnMobile}>
                 <img
                   src={item.image_url}
                   alt={`Image of ${item.name}`}
@@ -28,8 +28,8 @@ const CartTable = ({ cartItems }) => {
               <td>
                 <span>$</span> {item.sale_price.toFixed(2)}
               </td>
-              <td>{item.quantity}</td>
-              <td>
+              <td className={styles.hideOnMobile}>{item.quantity}</td>
+              <td className={styles.hideOnMobile}>
                 <span>$</span> {item.sale_price.toFixed(2) * item.quantity}
               </td>
             </tr>

--- a/src/components/Cart/CartTable.js
+++ b/src/components/Cart/CartTable.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import styles from './CartTable.module.scss';
+
+const CartTable = ({ cartItems }) => {
+  return (
+    <div className={styles.cartTable}>
+      <table>
+        <thead>
+          <tr>
+            <th></th>
+            <th>Product</th>
+            <th>Price</th>
+            <th>Quantity</th>
+            <th>Subtotal</th>
+          </tr>
+        </thead>
+        <tbody>
+          {cartItems.map((item, index) => (
+            <tr key={`cart-item-${index}`}>
+              <td>
+                <img
+                  src={item.image_url}
+                  alt={`Image of ${item.name}`}
+                  className={styles.cartImage}
+                />
+              </td>
+              <td>{item.name}</td>
+              <td>
+                <span>$</span> {item.sale_price.toFixed(2)}
+              </td>
+              <td>{item.quantity}</td>
+              <td>
+                <span>$</span> {item.sale_price.toFixed(2) * item.quantity}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default CartTable;

--- a/src/components/Cart/CartTable.module.scss
+++ b/src/components/Cart/CartTable.module.scss
@@ -8,5 +8,11 @@
     .cartImage {
       height: 90px;
     }
+
+    .hideOnMobile {
+      @media (max-width: $breakpoint-extra-small) {
+        display: none;
+      }
+    }
   }
 }

--- a/src/components/Cart/CartTable.module.scss
+++ b/src/components/Cart/CartTable.module.scss
@@ -1,0 +1,11 @@
+@import '@styles/Variables';
+
+.cartTable {
+  table {
+    width: 100%;
+
+    .cartImage {
+      height: 90px;
+    }
+  }
+}

--- a/src/components/Cart/CartTable.module.scss
+++ b/src/components/Cart/CartTable.module.scss
@@ -3,6 +3,7 @@
 .cartTable {
   table {
     width: 100%;
+    overflow-x: auto;
 
     .cartImage {
       height: 90px;

--- a/src/components/Cart/CartTotals.js
+++ b/src/components/Cart/CartTotals.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import styles from './CartTotals.module.scss';
+import classNames from 'classnames';
+
+const cx = classNames.bind(styles);
+
+const CartTotals = ({ cartSubTotal, cartTotal, checkout_url }) => {
+  return (
+    <div className={styles.cartTotals}>
+      <h3>Cart Totals</h3>
+      <table>
+        <tbody>
+          <tr>
+            <th>Subtotal</th>
+            <td>
+              <span>$</span>
+              {cartSubTotal}
+            </td>
+          </tr>
+          <tr>
+            <th>Total</th>
+            <td>
+              <span>$</span>
+              {cartTotal}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <a
+        href={checkout_url}
+        className={cx(styles.button, styles.checkoutButton)}
+      >
+        Checkout
+      </a>
+    </div>
+  );
+};
+
+export default CartTotals;

--- a/src/components/Cart/CartTotals.js
+++ b/src/components/Cart/CartTotals.js
@@ -29,8 +29,6 @@ const CartTotals = ({ cartSubTotal, cartTotal, checkout_url }) => {
       <a
         href={checkout_url}
         className={cx(styles.button, styles.checkoutButton)}
-        target='_blank'
-        rel='noreferrer'
       >
         Checkout
       </a>

--- a/src/components/Cart/CartTotals.js
+++ b/src/components/Cart/CartTotals.js
@@ -29,6 +29,8 @@ const CartTotals = ({ cartSubTotal, cartTotal, checkout_url }) => {
       <a
         href={checkout_url}
         className={cx(styles.button, styles.checkoutButton)}
+        target='_blank'
+        rel='noreferrer'
       >
         Checkout
       </a>

--- a/src/components/Cart/CartTotals.module.scss
+++ b/src/components/Cart/CartTotals.module.scss
@@ -1,0 +1,32 @@
+@import '@styles/Variables';
+
+.cartTotals {
+  float: right;
+
+  .checkoutButton {
+    width: 100%;
+    float: right;
+    text-align: center;
+  }
+
+  .button {
+    background-color: #107f67;
+    border-color: #107f67;
+    color: #ffffff;
+    display: block;
+    margin-bottom: 0.6180469716em;
+    border: 0;
+    border-radius: 0;
+    cursor: pointer;
+    padding: 0.6180469716em 1.41575em;
+    text-decoration: none;
+    font-weight: 600;
+    text-shadow: none;
+    word-break: break-all;
+    &:hover {
+      background-color: #00664e;
+      border-color: #00664e;
+      color: #ffffff;
+    }
+  }
+}

--- a/src/components/ContentWrapper/ContentWrapper.new.module.scss
+++ b/src/components/ContentWrapper/ContentWrapper.new.module.scss
@@ -51,10 +51,10 @@
       padding: 0 1em;
     }
 
-    // Very temporary!
     .gb-block-layout-column-inner {
       > h2:first-child {
         margin-top: 1.5em;
+        margin-bottom: 1.5em;
       }
     }
   }

--- a/src/components/EntryHeader/EntryHeader.module.scss
+++ b/src/components/EntryHeader/EntryHeader.module.scss
@@ -4,11 +4,6 @@
   color: var(--wpe--color--white);
   position: relative;
   overflow: hidden;
-  margin-bottom: 2rem;
-
-  @media (min-width: $breakpoint-small) {
-    margin-bottom: 5rem;
-  }
 }
 
 .has-image {
@@ -24,7 +19,7 @@
 .text {
   width: 100%;
   max-width: 72rem;
-  padding: 8.25rem 0;
+  padding: 6.25rem;
   position: relative;
   z-index: 1; // Pull text to the foreground to sit above <FeaturedImage />.
 }

--- a/src/components/Header/CartQuickView.js
+++ b/src/components/Header/CartQuickView.js
@@ -1,6 +1,8 @@
 import useAtlasEcom from '@hooks/useAtlasEcom';
+import { useRouter } from 'next/router';
 
 export function CartQuickView({ storeSettings, styles }) {
+  const router = useRouter();
   const { cartData } = useAtlasEcom();
 
   let cartSubTotal = (0).toFixed(2);
@@ -46,7 +48,7 @@ export function CartQuickView({ storeSettings, styles }) {
           </span>
         </a>
       </li>
-      {cartData ? (
+      {cartData && router.pathname !== '/cart' ? (
         <li>
           <div className={styles['widget_shopping_cart']}>
             <div className={styles['widget_shopping_cart_content']}>

--- a/src/components/Header/CartQuickView.js
+++ b/src/components/Header/CartQuickView.js
@@ -94,8 +94,6 @@ export function CartQuickView({ storeSettings, styles }) {
                 <a
                   href={cartData?.redirect_urls.checkout_url}
                   className={styles['button']}
-                  target='_blank'
-                  rel='noreferrer'
                 >
                   Checkout
                 </a>

--- a/src/components/Header/CartQuickView.js
+++ b/src/components/Header/CartQuickView.js
@@ -9,7 +9,7 @@ export function CartQuickView({ storeSettings, styles }) {
   let cartItems = [];
   let cartCount = 0;
 
-  if (cartData) {
+  if (cartData && cartData !== 'Empty') {
     cartSubTotal = cartData.cart_amount.toFixed(2);
     cartItems = [].concat(
       cartData.line_items.physical_items,
@@ -48,7 +48,7 @@ export function CartQuickView({ storeSettings, styles }) {
           </span>
         </a>
       </li>
-      {cartData && router.pathname !== '/cart' ? (
+      {cartData !== 'Empty' && router.pathname !== '/cart' ? (
         <li>
           <div className={styles['widget_shopping_cart']}>
             <div className={styles['widget_shopping_cart_content']}>
@@ -89,6 +89,8 @@ export function CartQuickView({ storeSettings, styles }) {
                 <a
                   href={cartData?.redirect_urls.checkout_url}
                   className={styles['button']}
+                  target='_blank'
+                  rel='noreferrer'
                 >
                   Checkout
                 </a>

--- a/src/components/Header/CartQuickView.js
+++ b/src/components/Header/CartQuickView.js
@@ -1,0 +1,102 @@
+import useAtlasEcom from '@hooks/useAtlasEcom';
+
+export function CartQuickView({ storeSettings, styles }) {
+  const { cartData } = useAtlasEcom();
+
+  let cartSubTotal = (0).toFixed(2);
+  let cartItems = [];
+  let cartCount = 0;
+
+  if (cartData) {
+    cartSubTotal = cartData.cart_amount.toFixed(2);
+    cartItems = [].concat(
+      cartData.line_items.physical_items,
+      cartData.line_items.custom_items,
+      cartData.line_items.digital_items,
+      cartData.line_items.gift_certificates
+    );
+    cartCount = cartItems.reduce((acc, item) => {
+      return acc + item.quantity;
+    }, 0);
+  }
+
+  return (
+    <ul id='site-header-cart' className={styles['site-header-cart']}>
+      <li className=''>
+        <a
+          className={styles['cart-contents']}
+          href='#'
+          title='View your shopping cart'
+        >
+          <span className={styles['price-amount']}>
+            <span>$</span>
+            {cartSubTotal}
+          </span>{' '}
+          <span className={styles['count']}>
+            {cartCount} item{cartCount === 1 ? '' : 's'}
+          </span>
+          <span className={styles['icon-cart']}>
+            <svg
+              xmlns='http://www.w3.org/2000/svg'
+              viewBox='0 0 576 512'
+              style={{ fill: storeSettings?.storeSecondaryColor }}
+            >
+              <path d='M171.7 191.1H404.3L322.7 35.07C316.6 23.31 321.2 8.821 332.9 2.706C344.7-3.409 359.2 1.167 365.3 12.93L458.4 191.1H544C561.7 191.1 576 206.3 576 223.1C576 241.7 561.7 255.1 544 255.1L492.1 463.5C484.1 492 459.4 512 430 512H145.1C116.6 512 91 492 83.88 463.5L32 255.1C14.33 255.1 0 241.7 0 223.1C0 206.3 14.33 191.1 32 191.1H117.6L210.7 12.93C216.8 1.167 231.3-3.409 243.1 2.706C254.8 8.821 259.4 23.31 253.3 35.07L171.7 191.1zM191.1 303.1C191.1 295.1 184.8 287.1 175.1 287.1C167.2 287.1 159.1 295.1 159.1 303.1V399.1C159.1 408.8 167.2 415.1 175.1 415.1C184.8 415.1 191.1 408.8 191.1 399.1V303.1zM271.1 303.1V399.1C271.1 408.8 279.2 415.1 287.1 415.1C296.8 415.1 304 408.8 304 399.1V303.1C304 295.1 296.8 287.1 287.1 287.1C279.2 287.1 271.1 295.1 271.1 303.1zM416 303.1C416 295.1 408.8 287.1 400 287.1C391.2 287.1 384 295.1 384 303.1V399.1C384 408.8 391.2 415.1 400 415.1C408.8 415.1 416 408.8 416 399.1V303.1z' />
+            </svg>
+          </span>
+        </a>
+      </li>
+      {cartData ? (
+        <li>
+          <div className={styles['widget_shopping_cart']}>
+            <div className={styles['widget_shopping_cart_content']}>
+              <ul className={styles['product_list_widget']}>
+                {cartItems.map((item) => (
+                  <li className={styles['mini_cart_item']} key={item.id}>
+                    <a href='#'>
+                      <img
+                        width='324'
+                        height='324'
+                        src={item.image_url}
+                        className={styles['thumbnail']}
+                        alt=''
+                      ></img>
+                      {item.name}
+                    </a>
+                    <span className={styles['quantity']}>
+                      {item.quantity} ×{' '}
+                      <span className={styles['price-amount']}>
+                        <span>$</span>
+                        {item.sale_price.toFixed(2)}
+                      </span>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+              <p className={styles['mini-cart__total']}>
+                <strong>Subtotal:</strong>{' '}
+                <span className={styles['price-amount']}>
+                  <span>$</span>
+                  {cartSubTotal}
+                </span>
+              </p>
+              <p className={styles['mini-cart__buttons']}>
+                <a href='/cart' className={styles['button']}>
+                  View cart
+                </a>
+                <a
+                  href={cartData?.redirect_urls.checkout_url}
+                  className={styles['button']}
+                >
+                  Checkout
+                </a>
+              </p>
+            </div>
+          </div>
+        </li>
+      ) : null}
+    </ul>
+  );
+}
+
+export default CartQuickView;

--- a/src/components/Header/CartQuickView.js
+++ b/src/components/Header/CartQuickView.js
@@ -25,10 +25,15 @@ export function CartQuickView({ storeSettings, styles }) {
   return (
     <ul id='site-header-cart' className={styles['site-header-cart']}>
       <li className=''>
-        <a
+        <div
           className={styles['cart-contents']}
-          href='#'
           title='View your shopping cart'
+          style={{
+            cursor:
+              !cartData || cartData === 'Empty' || router.pathname === '/cart'
+                ? 'auto'
+                : 'pointer',
+          }}
         >
           <span className={styles['price-amount']}>
             <span>$</span>
@@ -46,7 +51,7 @@ export function CartQuickView({ storeSettings, styles }) {
               <path d='M171.7 191.1H404.3L322.7 35.07C316.6 23.31 321.2 8.821 332.9 2.706C344.7-3.409 359.2 1.167 365.3 12.93L458.4 191.1H544C561.7 191.1 576 206.3 576 223.1C576 241.7 561.7 255.1 544 255.1L492.1 463.5C484.1 492 459.4 512 430 512H145.1C116.6 512 91 492 83.88 463.5L32 255.1C14.33 255.1 0 241.7 0 223.1C0 206.3 14.33 191.1 32 191.1H117.6L210.7 12.93C216.8 1.167 231.3-3.409 243.1 2.706C254.8 8.821 259.4 23.31 253.3 35.07L171.7 191.1zM191.1 303.1C191.1 295.1 184.8 287.1 175.1 287.1C167.2 287.1 159.1 295.1 159.1 303.1V399.1C159.1 408.8 167.2 415.1 175.1 415.1C184.8 415.1 191.1 408.8 191.1 399.1V303.1zM271.1 303.1V399.1C271.1 408.8 279.2 415.1 287.1 415.1C296.8 415.1 304 408.8 304 399.1V303.1C304 295.1 296.8 287.1 287.1 287.1C279.2 287.1 271.1 295.1 271.1 303.1zM416 303.1C416 295.1 408.8 287.1 400 287.1C391.2 287.1 384 295.1 384 303.1V399.1C384 408.8 391.2 415.1 400 415.1C408.8 415.1 416 408.8 416 399.1V303.1z' />
             </svg>
           </span>
-        </a>
+        </div>
       </li>
       {cartData !== 'Empty' && router.pathname !== '/cart' ? (
         <li>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -2,10 +2,10 @@ import React, { useEffect } from 'react';
 import { useState } from 'react';
 import { FaBars, FaSearch } from 'react-icons/fa';
 import { NavigationMenu, SkipNavigationLink } from '@components';
+import CartQuickView from './CartQuickView';
 import Link from 'next/link';
 import className from 'classnames/bind';
 import cookieCutter from 'cookie-cutter';
-import useAtlasEcom from '@hooks/useAtlasEcom';
 
 import styles from './Header.module.scss';
 
@@ -132,113 +132,9 @@ export default function Header({
             menuItems={menuItems}
           ></NavigationMenu>
 
-          <CartQuickView storeSettings={storeSettings} />
+          <CartQuickView storeSettings={storeSettings} styles={styles} />
         </div>
       </div>
     </header>
-  );
-}
-
-function CartQuickView({ storeSettings }) {
-  const { cartData } = useAtlasEcom();
-
-  let cartSubTotal = (0).toFixed(2);
-  let cartItems = [];
-  let cartCount = 0;
-
-  if (cartData) {
-    cartSubTotal = cartData.cart_amount.toFixed(2);
-    cartItems = [].concat(
-      cartData.line_items.physical_items,
-      cartData.line_items.custom_items,
-      cartData.line_items.digital_items,
-      cartData.line_items.gift_certificates
-    );
-    cartCount = cartItems.reduce((acc, item) => {
-      return acc + item.quantity;
-    }, 0);
-  }
-
-  return (
-    <ul id='site-header-cart' className={styles['site-header-cart']}>
-      <li className=''>
-        <a
-          className={styles['cart-contents']}
-          href='#'
-          title='View your shopping cart'
-        >
-          <span className={styles['price-amount']}>
-            <span>$</span>
-            {cartSubTotal}
-          </span>{' '}
-          <span className={styles['count']}>
-            {cartCount} item{cartCount === 1 ? '' : 's'}
-          </span>
-          <span className={styles['icon-cart']}>
-            <svg
-              xmlns='http://www.w3.org/2000/svg'
-              viewBox='0 0 576 512'
-              style={{ fill: storeSettings?.storeSecondaryColor }}
-            >
-              <path d='M171.7 191.1H404.3L322.7 35.07C316.6 23.31 321.2 8.821 332.9 2.706C344.7-3.409 359.2 1.167 365.3 12.93L458.4 191.1H544C561.7 191.1 576 206.3 576 223.1C576 241.7 561.7 255.1 544 255.1L492.1 463.5C484.1 492 459.4 512 430 512H145.1C116.6 512 91 492 83.88 463.5L32 255.1C14.33 255.1 0 241.7 0 223.1C0 206.3 14.33 191.1 32 191.1H117.6L210.7 12.93C216.8 1.167 231.3-3.409 243.1 2.706C254.8 8.821 259.4 23.31 253.3 35.07L171.7 191.1zM191.1 303.1C191.1 295.1 184.8 287.1 175.1 287.1C167.2 287.1 159.1 295.1 159.1 303.1V399.1C159.1 408.8 167.2 415.1 175.1 415.1C184.8 415.1 191.1 408.8 191.1 399.1V303.1zM271.1 303.1V399.1C271.1 408.8 279.2 415.1 287.1 415.1C296.8 415.1 304 408.8 304 399.1V303.1C304 295.1 296.8 287.1 287.1 287.1C279.2 287.1 271.1 295.1 271.1 303.1zM416 303.1C416 295.1 408.8 287.1 400 287.1C391.2 287.1 384 295.1 384 303.1V399.1C384 408.8 391.2 415.1 400 415.1C408.8 415.1 416 408.8 416 399.1V303.1z' />
-            </svg>
-          </span>
-        </a>
-      </li>
-      {cartData ? (
-        <li>
-          <div className={styles['widget_shopping_cart']}>
-            <div className={styles['widget_shopping_cart_content']}>
-              <ul className={styles['product_list_widget']}>
-                {cartItems.map((item) => (
-                  <li className={styles['mini_cart_item']} key={item.id}>
-                    <a href='#'>
-                      <img
-                        width='324'
-                        height='324'
-                        src={item.image_url}
-                        className={styles['thumbnail']}
-                        alt=''
-                      ></img>
-                      {item.name}
-                    </a>
-                    <span className={styles['quantity']}>
-                      {item.quantity} ×{' '}
-                      <span className={styles['price-amount']}>
-                        <span>$</span>
-                        {item.sale_price.toFixed(2)}
-                      </span>
-                    </span>
-                  </li>
-                ))}
-              </ul>
-              <p className={styles['mini-cart__total']}>
-                <strong>Subtotal:</strong>{' '}
-                <span className={styles['price-amount']}>
-                  <span>$</span>
-                  {cartSubTotal}
-                </span>
-              </p>
-              <p className={styles['mini-cart__buttons']}>
-                <a
-                  href={cartData?.redirect_urls.cart_url}
-                  className={styles['button']}
-                  target='_blank'
-                  rel='noreferrer'
-                >
-                  View cart
-                </a>
-                <a
-                  href={cartData?.redirect_urls.checkout_url}
-                  className={styles['button']}
-                >
-                  Checkout
-                </a>
-              </p>
-            </div>
-          </div>
-        </li>
-      ) : null}
-    </ul>
   );
 }

--- a/src/components/Loader/Loader.js
+++ b/src/components/Loader/Loader.js
@@ -1,0 +1,8 @@
+import React from 'react';
+import styles from './Loader.module.scss';
+
+const Loader = () => {
+  return <div className={styles.loader}></div>;
+};
+
+export default Loader;

--- a/src/components/Loader/Loader.module.scss
+++ b/src/components/Loader/Loader.module.scss
@@ -1,0 +1,31 @@
+@import '@styles/Variables';
+
+.loader {
+  border: 16px solid $color-light-gray;
+  border-radius: 50%;
+  border-top: 16px solid $color-green;
+  width: 120px;
+  height: 120px;
+  -webkit-animation: spin 2s linear infinite; /* Safari */
+  animation: spin 2s linear infinite;
+  margin: 0 auto;
+
+  /* Safari */
+  @-webkit-keyframes spin {
+    0% {
+      -webkit-transform: rotate(0deg);
+    }
+    100% {
+      -webkit-transform: rotate(360deg);
+    }
+  }
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+}

--- a/src/components/Loader/index.js
+++ b/src/components/Loader/index.js
@@ -1,0 +1,1 @@
+export { default as Loader } from './Loader';

--- a/src/components/ProductNotification/ProductNotification.js
+++ b/src/components/ProductNotification/ProductNotification.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import classNames from 'classnames';
+import styles from './ProductNotification.module.scss';
+
+const cx = classNames.bind(styles);
+
+const ProductNotification = ({ productNotification }) => {
+  return (
+    <div
+      className={cx(styles.notification, styles[productNotification.className])}
+    >
+      <div className={styles.message}>{productNotification.message}</div>
+      <a href='/cart'>View cart</a>
+    </div>
+  );
+};
+
+export default ProductNotification;

--- a/src/components/ProductNotification/ProductNotification.js
+++ b/src/components/ProductNotification/ProductNotification.js
@@ -4,13 +4,13 @@ import styles from './ProductNotification.module.scss';
 
 const cx = classNames.bind(styles);
 
-const ProductNotification = ({ productNotification }) => {
+const ProductNotification = ({ productNotification, cartPage }) => {
   return (
     <div
       className={cx(styles.notification, styles[productNotification.className])}
     >
       <div className={styles.message}>{productNotification.message}</div>
-      <a href='/cart'>View cart</a>
+      {!cartPage && <a href='/cart'>View cart</a>}
     </div>
   );
 };

--- a/src/components/ProductNotification/ProductNotification.module.scss
+++ b/src/components/ProductNotification/ProductNotification.module.scss
@@ -1,0 +1,17 @@
+.notification {
+  display: flex;
+  margin: 2.5em 0;
+  padding: 1em 2em 1em 3.5em;
+  border-left: 0.75em solid rgba(0, 0, 0, 0.15);
+  color: #fff;
+  background: #0f834d;
+
+  .message {
+    margin-right: auto;
+  }
+
+  a {
+    color: inherit;
+    text-decoration: underline;
+  }
+}

--- a/src/components/ProductNotification/index.js
+++ b/src/components/ProductNotification/index.js
@@ -1,0 +1,1 @@
+export { default as ProductNotification } from './ProductNotification';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -29,6 +29,7 @@ export { ProductMeta } from './ProductMeta';
 export { ProductFormField } from './ProductFormField';
 export { ProductDescription } from './ProductDescription';
 export { ProductGallery } from './ProductGallery';
+export { ProductNotification } from './ProductNotification';
 export { RelatedProducts } from './RelatedProducts';
 export { Reviews } from './Reviews';
 export { ReviewForm } from './ReviewForm';

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -16,6 +16,7 @@ export { PostInfo } from './PostInfo';
 export { SkipNavigationLink } from './SkipNavigationLink';
 export { Hero } from './Hero';
 export { LoadingSearchResult } from './LoadingSearchResult';
+export { Loader } from './Loader';
 export { Post } from './Post';
 export { SEO } from './SEO';
 export { SearchInput } from './SearchInput';

--- a/src/hooks/useAtlasEcom.js
+++ b/src/hooks/useAtlasEcom.js
@@ -50,7 +50,7 @@ async function fetchCart(body) {
 export const AtlasEcomContext = React.createContext({});
 
 export function AtlasEcomProvider({ children }) {
-  const [cartData, setCartData] = useState();
+  const [cartData, setCartData] = useState(null);
   const router = useRouter();
 
   useEffect(() => {
@@ -95,7 +95,7 @@ export function AtlasEcomProvider({ children }) {
       });
     }
 
-    setCartData(data.cart_data);
+    setCartData(data.cart_data ?? 'Empty');
   }
 
   const value = {

--- a/src/hooks/useAtlasEcom.js
+++ b/src/hooks/useAtlasEcom.js
@@ -94,7 +94,7 @@ export function AtlasEcomProvider({ children }) {
         return data;
       }
     } catch (e) {
-      console.err(e);
+      console.error(e);
       return e;
     }
   }

--- a/src/hooks/useAtlasEcom.js
+++ b/src/hooks/useAtlasEcom.js
@@ -85,6 +85,20 @@ export function AtlasEcomProvider({ children }) {
     return data;
   }
 
+  async function removeFromCart(itemId) {
+    try {
+      const data = await fetchCart({ action: 'remove', item_id: itemId });
+
+      if (data.status === 200 && data.message) {
+        await checkCart();
+        return data;
+      }
+    } catch (e) {
+      console.err(e);
+      return e;
+    }
+  }
+
   async function checkCart() {
     const data = await fetchCart({ action: 'check' });
 
@@ -101,6 +115,7 @@ export function AtlasEcomProvider({ children }) {
   const value = {
     cartData,
     addToCart,
+    removeFromCart,
     checkCart,
   };
 

--- a/src/pages/[...wordpressNode].js
+++ b/src/pages/[...wordpressNode].js
@@ -4,7 +4,12 @@ export default function Page(props) {
   return <WordPressTemplate {...props} />;
 }
 
-export function getStaticProps(ctx) {
+export async function getStaticProps(ctx) {
+  // use isr for the shop page
+  if (ctx.params.wordpressNode[0] === 'shop') {
+    return { ...(await getWordPressProps({ ctx })), revalidate: 5 };
+  }
+
   return getWordPressProps({ ctx });
 }
 

--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -36,7 +36,7 @@ export default function Page() {
   let cartCount = 0;
   let cartTotal = 0;
 
-  if (cartData) {
+  if (cartData && cartData !== 'Empty') {
     cartTotal = cartData.cart_amount.toFixed(2);
     cartSubTotal = cartData.base_amount.toFixed(2);
     cartItems = [].concat(
@@ -64,7 +64,7 @@ export default function Page() {
         <Container>
           <EntryHeader title='Cart' />
           <div className={styles.cartDetails}>
-            {cartData ? (
+            {cartData !== 'Empty' && cartData !== null && (
               <>
                 <CartTable
                   cartItems={cartItems}
@@ -78,9 +78,8 @@ export default function Page() {
                   checkout_url={cartData?.redirect_urls.checkout_url}
                 />
               </>
-            ) : (
-              <p>You have no items in cart</p>
             )}
+            {cartData === 'Empty' && <p>You have no items in cart</p>}
           </div>
         </Container>
       </Main>

--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -1,0 +1,115 @@
+import { gql, useQuery } from '@apollo/client';
+import * as MENUS from '@constants/menus';
+import { BlogInfoFragment } from '@fragments/GeneralSettings';
+import { StoreSettingsFragment } from '@fragments/StoreSettings';
+import { BannerFragment } from '@fragments/Banners';
+import useAtlasEcom from '@hooks/useAtlasEcom';
+import {
+  Banner,
+  Header,
+  Footer,
+  Main,
+  Container,
+  EntryHeader,
+  NavigationMenu,
+  SEO,
+} from '@components';
+
+export default function Page() {
+  const { data } = useQuery(Page.query, {
+    variables: Page.variables(),
+  });
+
+  const { title: siteTitle, description: siteDescription } =
+    data?.generalSettings ?? {};
+  const banner = data?.banners?.nodes[0];
+  const primaryMenu = data?.headerMenuItems?.nodes ?? [];
+  const footerMenu = data?.footerMenuItems?.nodes ?? [];
+
+  const { cartData } = useAtlasEcom();
+
+  let cartSubTotal = (0).toFixed(2);
+  let cartItems = [];
+  let cartCount = 0;
+
+  if (cartData) {
+    cartSubTotal = cartData.cart_amount.toFixed(2);
+    cartItems = [].concat(
+      cartData.line_items.physical_items,
+      cartData.line_items.custom_items,
+      cartData.line_items.digital_items,
+      cartData.line_items.gift_certificates
+    );
+    cartCount = cartItems.reduce((acc, item) => {
+      return acc + item.quantity;
+    }, 0);
+  }
+
+  return (
+    <>
+      <SEO title={siteTitle} description={siteDescription} />
+      <Header
+        title={siteTitle}
+        description={siteDescription}
+        menuItems={primaryMenu}
+        storeSettings={data?.storeSettings}
+      />
+      <Banner notificationBanner={banner} />
+      <Main>
+        <Container>
+          <EntryHeader title='Cart' />
+          <div className='row row-wrap'>
+            {cartData ? (
+              <p>A Table of Cart Data</p>
+            ) : (
+              <p>You have no items in cart</p>
+            )}
+          </div>
+        </Container>
+      </Main>
+      <Footer title={siteTitle} menuItems={footerMenu} />
+    </>
+  );
+}
+
+Page.query = gql`
+  ${BlogInfoFragment}
+  ${BannerFragment}
+  ${NavigationMenu.fragments.entry}
+  ${StoreSettingsFragment}
+  query GetPageData(
+    $headerLocation: MenuLocationEnum
+    $footerLocation: MenuLocationEnum
+  ) {
+    generalSettings {
+      ...BlogInfoFragment
+    }
+    storeSettings {
+      nodes {
+        ...StoreSettingsFragment
+      }
+    }
+    banners {
+      nodes {
+        ...BannerFragment
+      }
+    }
+    headerMenuItems: menuItems(where: { location: $headerLocation }) {
+      nodes {
+        ...NavigationMenuItemFragment
+      }
+    }
+    footerMenuItems: menuItems(where: { location: $footerLocation }) {
+      nodes {
+        ...NavigationMenuItemFragment
+      }
+    }
+  }
+`;
+
+Page.variables = () => {
+  return {
+    headerLocation: MENUS.PRIMARY_LOCATION,
+    footerLocation: MENUS.FOOTER_LOCATION,
+  };
+};

--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { gql, useQuery } from '@apollo/client';
 import * as MENUS from '@constants/menus';
 import { BlogInfoFragment } from '@fragments/GeneralSettings';
@@ -16,10 +17,13 @@ import {
   EntryHeader,
   NavigationMenu,
   Loader,
+  ProductNotification,
   SEO,
 } from '@components';
 
 export default function Page() {
+  const [productNotification, setProductNotification] = useState();
+
   const { data } = useQuery(Page.query, {
     variables: Page.variables(),
   });
@@ -63,6 +67,12 @@ export default function Page() {
       <Banner notificationBanner={banner} />
       <Main>
         <Container>
+          {productNotification && (
+            <ProductNotification
+              productNotification={productNotification}
+              cartPage
+            />
+          )}
           <EntryHeader title='Cart' />
           <div className={styles.cartDetails}>
             {cartData !== 'Empty' && cartData !== null && (
@@ -72,6 +82,7 @@ export default function Page() {
                   cartCount={cartCount}
                   cartSubTotal={cartSubTotal}
                   cartTotal={cartTotal}
+                  setProductNotification={setProductNotification}
                 />
                 <CartTotals
                   cartSubTotal={cartSubTotal}

--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -4,6 +4,9 @@ import { BlogInfoFragment } from '@fragments/GeneralSettings';
 import { StoreSettingsFragment } from '@fragments/StoreSettings';
 import { BannerFragment } from '@fragments/Banners';
 import useAtlasEcom from '@hooks/useAtlasEcom';
+import CartTable from '@components/Cart/CartTable';
+import CartTotals from '@components/Cart/CartTotals';
+import styles from '@styles/pages/_Cart.module.scss';
 import {
   Banner,
   Header,
@@ -31,9 +34,11 @@ export default function Page() {
   let cartSubTotal = (0).toFixed(2);
   let cartItems = [];
   let cartCount = 0;
+  let cartTotal = 0;
 
   if (cartData) {
-    cartSubTotal = cartData.cart_amount.toFixed(2);
+    cartTotal = cartData.cart_amount.toFixed(2);
+    cartSubTotal = cartData.base_amount.toFixed(2);
     cartItems = [].concat(
       cartData.line_items.physical_items,
       cartData.line_items.custom_items,
@@ -58,9 +63,21 @@ export default function Page() {
       <Main>
         <Container>
           <EntryHeader title='Cart' />
-          <div className='row row-wrap'>
+          <div className={styles.cartDetails}>
             {cartData ? (
-              <p>A Table of Cart Data</p>
+              <>
+                <CartTable
+                  cartItems={cartItems}
+                  cartCount={cartCount}
+                  cartSubTotal={cartSubTotal}
+                  cartTotal={cartTotal}
+                />
+                <CartTotals
+                  cartSubTotal={cartSubTotal}
+                  cartTotal={cartTotal}
+                  checkout_url={cartData?.redirect_urls.checkout_url}
+                />
+              </>
             ) : (
               <p>You have no items in cart</p>
             )}

--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -15,6 +15,7 @@ import {
   Container,
   EntryHeader,
   NavigationMenu,
+  Loader,
   SEO,
 } from '@components';
 
@@ -80,6 +81,7 @@ export default function Page() {
               </>
             )}
             {cartData === 'Empty' && <p>You have no items in cart</p>}
+            {cartData === null && <Loader />}
           </div>
         </Container>
       </Main>

--- a/src/styles/_Variables.scss
+++ b/src/styles/_Variables.scss
@@ -17,5 +17,6 @@ $color-white: #ffff;
 $color-green: #107f67;
 $color-red: #f00;
 $color-gray: #999;
+$color-light-gray: #f8f8f8;
 $color-light-red: #ffe3e3;
 $color-light-green: #e3ffe3;

--- a/src/styles/pages/_Cart.module.scss
+++ b/src/styles/pages/_Cart.module.scss
@@ -1,0 +1,16 @@
+@import '@styles/Variables';
+
+.cartDetails {
+  table {
+    th {
+      background-color: $color-light-gray;
+      text-align: left;
+      padding: 1.5em;
+    }
+
+    td {
+      border-bottom: 1px solid $color-light-gray;
+      padding: 1.5em;
+    }
+  }
+}

--- a/src/styles/pages/_Product.module.scss
+++ b/src/styles/pages/_Product.module.scss
@@ -46,24 +46,6 @@
     max-width: initial;
   }
 
-  .notification {
-    display: flex;
-    margin: 2.5em 0;
-    padding: 1em 2em 1em 3.5em;
-    border-left: 0.75em solid rgba(0, 0, 0, 0.15);
-    color: #fff;
-    background: #0f834d;
-
-    .message {
-      margin-right: auto;
-    }
-
-    a {
-      color: inherit;
-      text-decoration: underline;
-    }
-  }
-
   .notificationError {
     background-color: #c00;
   }

--- a/src/styles/pages/_Product.module.scss
+++ b/src/styles/pages/_Product.module.scss
@@ -1,8 +1,8 @@
 @import '@styles/Variables';
 
 .product {
-  margin-top: 1em !important;
-  margin-bottom: 1em !important;
+  margin-top: 3.5em !important;
+  margin-bottom: 3.5em !important;
 
   .productGallery {
     @media (min-width: $breakpoint-small) {

--- a/src/wp-templates/product.js
+++ b/src/wp-templates/product.js
@@ -16,6 +16,7 @@ import {
   ProductPrice,
   ProductDescription,
   ProductGallery,
+  ProductNotification,
   RelatedProducts,
   Reviews,
   ReviewForm,
@@ -64,7 +65,7 @@ export default function Component(props) {
     [productFormFields]
   );
 
-  const { cartData, addToCart } = useAtlasEcom();
+  const { addToCart } = useAtlasEcom();
 
   const [productNotification, setProductNotification] = useState();
 
@@ -193,19 +194,9 @@ export default function Component(props) {
       <Banner notificationBanner={banner} />
       <Main>
         <Container classes={cx(styles.product)}>
-          {productNotification ? (
-            <div
-              className={cx(
-                styles.notification,
-                styles[productNotification.className]
-              )}
-            >
-              <div className={styles.message}>
-                {productNotification.message}
-              </div>
-              <a href={cartData?.redirect_urls?.cart_url}>View cart</a>
-            </div>
-          ) : null}
+          {productNotification && (
+            <ProductNotification productNotification={productNotification} />
+          )}
 
           <div className='row'>
             <div className='column column-40'>


### PR DESCRIPTION
### Description
This PR creates a shop page using the Next.js routing pattern with a `cart.js` file in page dir. 

Features: 
- `cart.js `page showing a table with the items in the cart and the total price, checkout button
- `cartTable` `cartTotals` and `Loader` components to place UI on the cart page
- Moved the `QuickCartView` component from the `Header` to own component 
- Added responsiveness and tweaked some CSS for above, including removing user interactions on the `CartQuickView` when on cart page etc 
- Added a `removeFromCart` function to `useAtlasEcom` hook which depends on a [change in the Atlas Commerce Connector BigCommerce plugin outlined in this PR](https://github.com/wpengine/atlas-commerce-connector-bigcommerce/pull/26)
- Added Incremental Static Regeneration on the shop page so that we can catch updates to the product sync, let's test this when merged to main. 

### Testing 

- Make sure you have the change in the [Atlas Commerce Connector BigCommerce plugin outlined in this PR ](https://github.com/wpengine/atlas-commerce-connector-bigcommerce/pull/26) running in WP locally
- Test adding and removing items from cart, opening the checkout and reflecting changes back and forth, plus in the `CartQuickView` component, emptying the cart etc 

_**Note**: The checkout page on BigCommerce has a link to edit cart would be good to see if we can redirect this back to our cart or else hide it._ 

### Screenshots

<img width="1276" alt="Screenshot 2022-11-24 at 11 21 18" src="https://user-images.githubusercontent.com/48026075/203830153-2801d8d2-547b-44dc-9fa4-70512ae615ba.png">




