### PR TITLE
style: adding white bg color to sale label

### DIFF
--- a/src/components/ProductSummary/ProductSummary.module.scss
+++ b/src/components/ProductSummary/ProductSummary.module.scss
@@ -22,6 +22,7 @@
     margin-bottom: 1em;
     border-radius: 3px;
     position: absolute;
+    background-color: $color-white;
   }
   .productImage {
     width: 100%;

--- a/src/components/SearchResults/SearchResults.module.scss
+++ b/src/components/SearchResults/SearchResults.module.scss
@@ -61,6 +61,7 @@ $color-grey: #777;
       margin-bottom: 1em;
       border-radius: 3px;
       position: absolute;
+      background-color: $color-white;
     }
     .productImage {
       width: 100%;

--- a/src/styles/pages/_Product.module.scss
+++ b/src/styles/pages/_Product.module.scss
@@ -41,6 +41,7 @@
     margin-bottom: 1em;
     border-radius: 3px;
     position: relative;
+    background-color: $color-white;
   }
   img {
     max-width: initial;

--- a/src/styles/pages/_Shop.module.scss
+++ b/src/styles/pages/_Shop.module.scss
@@ -39,6 +39,7 @@
       margin-bottom: 1em;
       border-radius: 3px;
       position: absolute;
+      background-color: $color-white;
     }
     .productImage {
       width: 100%;


### PR DESCRIPTION
Sale items now have a white bg color so they can be visible on dark thumbnails