### PR TITLE
[TITAN-148] - Product Categories should be able to return as null for a product

### DIFF
--- a/src/components/ProductMeta/ProductMeta.js
+++ b/src/components/ProductMeta/ProductMeta.js
@@ -1,11 +1,15 @@
 import React from 'react';
-import { checkPurchaseDisabled } from '../../helpers/productHelpers.js';
+import {
+  checkPurchaseDisabled,
+  getProductCategories,
+} from '../../helpers/productHelpers.js';
 import { ProductFormField, Button } from '@components';
 import Link from 'next/link';
 import styles from './ProductMeta.module.scss';
 
 const ProductMeta = ({
   product,
+  categories,
   sortedFormFields,
   handleChange,
   handleSubmit,
@@ -37,7 +41,11 @@ const ProductMeta = ({
 
   const displayProduct = productVariant ?? product;
   const productBrand = product.brand?.node;
-  const productCategories = product.productCategories?.edges;
+  const categoriesForThisProduct = getProductCategories(
+    categories,
+    product.bigCommerceID,
+    product.slug
+  );
 
   let purchaseDisabledMessage =
     modifierPurchaseDisabled.purchaseDisabledMessage ||
@@ -47,22 +55,22 @@ const ProductMeta = ({
     <div className={styles.productMeta}>
       <p>SKU: {displayProduct?.sku}</p>
 
-      {productCategories?.length ? (
+      {categoriesForThisProduct.length >= 1 && (
         <p>
           Categories:{' '}
-          {productCategories.map((category, index) => (
-            <span key={category.node.id}>
+          {categoriesForThisProduct.map((category, index) => (
+            <span key={category.id}>
               {index === 0 ? '' : ', '}
               <Link
-                href={`/product-category/${category.node.slug}`}
-                key={category.node.id}
+                href={`/product-category/${category.slug}`}
+                key={category.id}
               >
-                <a>{category.node.name}</a>
+                <a>{category.name}</a>
               </Link>
             </span>
           ))}
         </p>
-      ) : null}
+      )}
 
       {productBrand ? <p>Brand: {productBrand.name}</p> : null}
 

--- a/src/components/SearchRecommendations/SearchRecommendations.js
+++ b/src/components/SearchRecommendations/SearchRecommendations.js
@@ -12,9 +12,9 @@ export default function SearchRecommendations({ categories }) {
       <h4>Browse by Category</h4>
       <ul>
         {categories?.map((category) => (
-          <li key={category?.node?.databaseId ?? 0}>
-            <Link href={'/product-category/' + category?.node?.slug ?? '#'}>
-              <a>{category?.node.name}</a>
+          <li key={category?.databaseId ?? 0}>
+            <Link href={'/product-category/' + category?.slug ?? '#'}>
+              <a>{category?.name}</a>
             </Link>
           </li>
         ))}

--- a/src/fragments/ProductCategories.js
+++ b/src/fragments/ProductCategories.js
@@ -1,0 +1,15 @@
+import { gql } from '@apollo/client';
+
+export const ProductCategoryFragment = gql`
+  fragment ProductCategoryFragment on ProductCategory {
+    databaseId
+    id
+    slug
+    name
+    products {
+      nodes {
+        bigCommerceID
+      }
+    }
+  }
+`;

--- a/src/fragments/Products.js
+++ b/src/fragments/Products.js
@@ -42,15 +42,6 @@ export const ProductFragment = gql`
     bigCommerceID
     slug
     productFormFieldsJson
-    productCategories {
-      edges {
-        node {
-          id
-          name
-          slug
-        }
-      }
-    }
     relatedProducts
     variantLookupJson
     modifierLookupJson

--- a/src/helpers/productHelpers.js
+++ b/src/helpers/productHelpers.js
@@ -98,3 +98,26 @@ export function checkPurchaseDisabled(
 
   return { purchaseDisabled, purchaseDisabledMessage };
 }
+
+/**
+ * Checks the list of categories to see if the current product is associated with any. Returns the list of categories for that product or an empty array.
+ */
+export function getProductCategories(
+  categories,
+  productBigCommerceId,
+  productSlug
+) {
+  const thisProductsCategories = categories.filter((category) => {
+    const foundProduct = category.products.nodes.find(
+      (product) =>
+        product.bigCommerceID === productBigCommerceId &&
+        product.slug === productSlug
+    );
+
+    if (foundProduct) {
+      return category.name;
+    }
+  });
+
+  return thisProductsCategories ?? [];
+}

--- a/src/wp-templates/page-search.js
+++ b/src/wp-templates/page-search.js
@@ -3,6 +3,7 @@ import { gql } from '@apollo/client';
 import { getWordPressProps } from '@faustwp/core';
 import { BlogInfoFragment } from '@fragments/GeneralSettings';
 import { StoreSettingsFragment } from '@fragments/StoreSettings';
+import { ProductCategoryFragment } from '@fragments/ProductCategories';
 import {
   Banner,
   Button,
@@ -26,7 +27,7 @@ export default function Page(props) {
   const primaryMenu = props?.data?.headerMenuItems?.nodes ?? [];
   const footerMenu = props?.data?.footerMenuItems?.nodes ?? [];
   const storeSettings = props?.data?.storeSettings?.nodes ?? [];
-  const productCategories = props?.data?.productCategories?.edges ?? [];
+  const productCategories = props?.data?.productCategories?.nodes ?? [];
 
   const {
     searchQuery,
@@ -108,6 +109,7 @@ Page.query = gql`
   ${NavigationMenu.fragments.entry}
   ${FeaturedImage.fragments.entry}
   ${StoreSettingsFragment}
+  ${ProductCategoryFragment}
   query GetPageData(
     $databaseId: ID!
     $headerLocation: MenuLocationEnum
@@ -138,13 +140,8 @@ Page.query = gql`
       }
     }
     productCategories {
-      edges {
-        node {
-          databaseId
-          id
-          name
-          slug
-        }
+      nodes {
+        ...ProductCategoryFragment
       }
     }
   }

--- a/src/wp-templates/product.js
+++ b/src/wp-templates/product.js
@@ -42,6 +42,7 @@ export default function Component(props) {
   const primaryMenu = props?.data?.headerMenuItems?.nodes ?? [];
   const footerMenu = props?.data?.footerMenuItems?.nodes ?? [];
   const product = props?.data?.product ?? {};
+  const productCategories = props?.data?.productCategories?.nodes ?? [];
 
   let relatedProductIds = [];
   try {
@@ -220,6 +221,7 @@ export default function Component(props) {
 
               <ProductMeta
                 product={product}
+                categories={productCategories}
                 sortedFormFields={sortedFormFields}
                 handleChange={handleChange}
                 handleSubmit={handleSubmit}
@@ -263,6 +265,20 @@ Component.query = gql`
   ) {
     product(id: $databaseId, idType: DATABASE_ID, asPreview: $asPreview) {
       ...ProductFragment
+    }
+    productCategories {
+      nodes {
+        databaseId
+        id
+        slug
+        name
+        products {
+          nodes {
+            slug
+            bigCommerceID
+          }
+        }
+      }
     }
     generalSettings {
       ...BlogInfoFragment


### PR DESCRIPTION
### Description 
If a product is synced with no categories this returns a `500` error when trying to render the product page. GraphQL returns an error with this part of the product query: 
_"debugMessage": "Cannot return null for non-nullable field "ProductToProductCategoryConnection.edges".",_
```
productCategories {
  edges {
    node {
      id
      name
      slug
    }
  }
}
```

Instead of pulling the product and its related `productCategories`, which cannot be `null`, this change requests all the `productCategories` and their related `products` and then uses a helper function `getProductCategories` to filter the ones which have that product assoc with it (by `slug` and `bigCommerceID`), if no categories are assoc with the product provided, then we can just return an empty array from the helper and render nothing for the categories instead of getting a 500 error. 

Also moves the query for `ProductCategories` on the `search` page to own fragment. It is not a fragment on the product page because it has to be explicit in the `GetProduct` query. 