### PR TITLE
[TITAN-155] - Footer logo size on mobile

### DIFF
--- a/src/components/Header/Header.module.scss
+++ b/src/components/Header/Header.module.scss
@@ -31,7 +31,6 @@
 .logo img {
   width: 100px;
   height: auto;
-  float: left;
   margin-right: 15px;
 }
 

--- a/src/components/Socials/Socials.module.scss
+++ b/src/components/Socials/Socials.module.scss
@@ -1,9 +1,15 @@
+@import '@styles/Variables';
+
 .socials {
   display: flex;
   justify-content: space-evenly;
   margin: 40px 0px 40px 0px;
 
   .socialIcon {
-    height: 60px;
+    height: 50px;
+
+    @media (max-width: $breakpoint-extra-small) {
+      height: 30px;
+    }
   }
 }


### PR DESCRIPTION
### Description 

- Fitting the footer logos on mobile and making slightly smaller (neater) on mobile and desktop
- I also removed floating the logo to the left of the site title as it was too inconsistent on all devices - largely depended on the size of the title. Now the logo just sits on top or is excluded altogether if not included so the title is un affected in both instances. 