### PR TITLE
fix: return null instead of errors if no store logo

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -36,10 +36,9 @@ export default function Header({
 
   var storeLogo = null;
   try {
-    storeLogo =
-      storeSettings?.nodes[0].storeLogo != undefined
-        ? JSON.parse(storeSettings?.nodes[0].storeLogo)
-        : '';
+    storeLogo = storeSettings?.nodes[0]?.storeLogo
+      ? JSON.parse(storeSettings?.nodes[0].storeLogo)
+      : null;
   } catch (err) {
     console.log('error', err);
   }
@@ -78,7 +77,9 @@ export default function Header({
           <div className={styles['logo']}>
             <Link href='/'>
               <a title='Home'>
-                {storeLogo.url && <img src={storeLogo.url} alt='Store Logo' />}
+                {storeLogo?.url && (
+                  <img src={storeLogo?.url} alt='Store Logo' />
+                )}
                 <h3 style={{ color: storeSettings?.storeSecondaryColor }}>
                   {title}
                 </h3>


### PR DESCRIPTION
### Description 

If the store logo CPT didn't exist or store logo was changed then the frontend was being brought down, changing this just to return null for that property so we don't block rendering the header 