### PR TITLE
build: add isr to search page

### DIFF
--- a/src/pages/[...wordpressNode].js
+++ b/src/pages/[...wordpressNode].js
@@ -5,7 +5,6 @@ export default function Page(props) {
 }
 
 export async function getStaticProps(ctx) {
-  // use isr for the shop, search and product pages
   if (
     ctx.params.wordpressNode[0] === 'shop' ||
     ctx.params.wordpressNode[0] === 'product' ||

--- a/src/pages/[...wordpressNode].js
+++ b/src/pages/[...wordpressNode].js
@@ -5,10 +5,11 @@ export default function Page(props) {
 }
 
 export async function getStaticProps(ctx) {
-  // use isr for the shop and product pages
+  // use isr for the shop, search and product pages
   if (
     ctx.params.wordpressNode[0] === 'shop' ||
-    ctx.params.wordpressNode[0] === 'product'
+    ctx.params.wordpressNode[0] === 'product' ||
+    ctx.params.wordpressNode[0] === 'search'
   ) {
     return { ...(await getWordPressProps({ ctx })), revalidate: 5 };
   }


### PR DESCRIPTION
### Description 

I noticed after e2e testing that the search page doesn't list `product categories `after a sync unless a rebuild is triggered in Atlas - so I added it to the list of pages that use `ISR`

### Testing 

I tested that the categories appear after a sync and a rebuild - when this is merged we can test if it lists them after a sync and refreshing the page a number of times.  