### PR TITLE
[titan-194] feat: bumping web vitals

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,8 @@
   "dependencies": {
     "@apollo/client": "^3.6.6",
     "@blacklab/react-image-magnify": "^4.1.1",
-    "@faustwp/cli": "0.1.1",
-    "@faustwp/core": "0.1.1",
-    "@fortawesome/fontawesome-free": "^6.2.1",
+    "@faustwp/cli": "0.2.0",
+    "@faustwp/core": "0.2.0",
     "@wordpress/base-styles": "^4.7.0",
     "@wordpress/block-library": "^7.13.0",
     "classnames": "^2.3.1",

--- a/src/components/Cart/CartTable.js
+++ b/src/components/Cart/CartTable.js
@@ -46,6 +46,7 @@ const CartTable = ({ cartItems, setProductNotification }) => {
                   src={item.image_url}
                   alt={`Image of ${item.name}`}
                   className={styles.cartImage}
+                  loading='lazy'
                 />
               </td>
               <td>{item.name}</td>

--- a/src/components/Header/CartQuickView.js
+++ b/src/components/Header/CartQuickView.js
@@ -67,6 +67,7 @@ export function CartQuickView({ storeSettings, styles }) {
                         src={item.image_url}
                         className={styles['thumbnail']}
                         alt=''
+                        loading='lazy'
                       ></img>
                       {item.name}
                     </a>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -78,7 +78,7 @@ export default function Header({
             <Link href='/'>
               <a title='Home'>
                 {storeLogo?.url && (
-                  <img src={storeLogo?.url} alt='Store Logo' />
+                  <img src={storeLogo?.url} alt='Store Logo' loading='lazy' />
                 )}
                 <h3 style={{ color: storeSettings?.storeSecondaryColor }}>
                   {title}

--- a/src/components/ProductGallery/ProductGallery.js
+++ b/src/components/ProductGallery/ProductGallery.js
@@ -1,7 +1,16 @@
 import React, { useState } from 'react';
-import ReactImageMagnify from '@blacklab/react-image-magnify';
-import Slider from 'react-slick';
 import styles from '@styles/pages/_Product.module.scss';
+import dynamic from 'next/dynamic';
+
+import 'slick-carousel/slick/slick.css';
+import 'slick-carousel/slick/slick-theme.css';
+
+const ReactImageMagnify = dynamic(() => import('@blacklab/react-image-magnify'), {
+  ssr: false,
+});
+const Slider = dynamic(() => import('react-slick'), {
+  ssr: false,
+});
 
 function ProductGallery({ images }) {
   const [productIndex, setProductIndex] = useState(0);
@@ -29,7 +38,7 @@ function ProductGallery({ images }) {
 
       <Slider dots={false} infinite={false} slidesToShow={4} slidesToScroll={4}>
         {!images.length ? (
-          <img alt='Missing product image' src='/ProductDefault.gif' />
+          <img alt='Missing product image' src='/ProductDefault.gif' loading='lazy' />
         ) : (
           images.map((image, index) => (
             <img
@@ -38,6 +47,7 @@ function ProductGallery({ images }) {
               onClick={() => setProductIndex(index)}
               key={`slide-image-${index}`}
               alt={image?.description}
+              loading='lazy'
             />
           ))
         )}

--- a/src/components/ProductSummary/ProductSummary.js
+++ b/src/components/ProductSummary/ProductSummary.js
@@ -30,6 +30,7 @@ export default function ProductSummary({ product }) {
               className={styles.productImage}
               src={thumbnail?.urlThumbnail ?? '/ProductDefault.gif'}
               alt={product?.imageAltText ?? product?.name}
+              loading='lazy'
             />
           </a>
         </Link>

--- a/src/components/ProductSummary/ProductSummary.module.scss
+++ b/src/components/ProductSummary/ProductSummary.module.scss
@@ -26,6 +26,7 @@
   }
   .productImage {
     width: 80%;
+    height: auto;
 
     @media (max-width: $breakpoint-extra-small) {
       width: auto;

--- a/src/components/ReviewForm/ReviewForm.js
+++ b/src/components/ReviewForm/ReviewForm.js
@@ -3,7 +3,6 @@ import styles from './ReviewForm.module.scss';
 import classNames from 'classnames';
 import { Button } from '@components/Button';
 import { validateReview } from '../../helpers/validateReview';
-import '@fortawesome/fontawesome-free/css/all.min.css';
 
 const cx = classNames.bind(styles);
 
@@ -88,6 +87,7 @@ export default function ReviewForm({ product }) {
                 src={productImage.urlThumbnail}
                 alt={product.name}
                 className={styles.productImage}
+                loading='lazy'
               />
               <h6 className={styles.productBrand}>
                 {product.brand?.node?.name}

--- a/src/components/ReviewForm/ReviewForm.module.scss
+++ b/src/components/ReviewForm/ReviewForm.module.scss
@@ -37,6 +37,7 @@
   }
   .productImage {
     width: 50%;
+    height: auto;
   }
   .formField {
     label {

--- a/src/components/Reviews/Review.js
+++ b/src/components/Reviews/Review.js
@@ -35,7 +35,7 @@ export default function Review({ review, styles }) {
               aria-label={`Rated ${review.rating} out of 5`}
               style={{"--rating":review.rating}}
             >
-              <span style={{display: "none"}}>
+              <span style={{ width: `${review.rating * 20}%` }}>
                 Rated <strong className='rating'>{review.rating}</strong> out of
                 5 based on <span className='rating'>1</span> customer rating
               </span>

--- a/src/components/Reviews/Review.js
+++ b/src/components/Reviews/Review.js
@@ -1,5 +1,3 @@
-import '@fortawesome/fontawesome-free/css/all.min.css';
-
 const months = [
   'January',
   'February',
@@ -35,8 +33,9 @@ export default function Review({ review, styles }) {
               className={styles.starRating}
               role='img'
               aria-label={`Rated ${review.rating} out of 5`}
+              style={{"--rating":review.rating}}
             >
-              <span style={{ width: `${review.rating * 20}%` }}>
+              <span style={{display: "none"}}>
                 Rated <strong className='rating'>{review.rating}</strong> out of
                 5 based on <span className='rating'>1</span> customer rating
               </span>

--- a/src/components/Reviews/Reviews.module.scss
+++ b/src/components/Reviews/Reviews.module.scss
@@ -30,38 +30,18 @@
         float: right;
         margin-right: 0;
         .starRating {
-          margin-right: 0.5em;
-          overflow: hidden;
-          position: relative;
-          height: 1.618em;
-          line-height: 1.618;
-          font-size: 1em;
-          width: 5.55em;
-          font-family: 'Font Awesome 5 Free';
-          font-weight: 900;
-          &:before {
-            opacity: 0.25;
-            float: left;
-            content: '\f005\f005\f005\f005\f005';
-            top: 0px;
-            left: 0px;
-            position: absolute;
-          }
-          span {
-            overflow: hidden;
-            float: left;
-            top: 0;
-            left: 0;
-            position: absolute;
-            padding-top: 1.5em;
-            color: $primary-color;
-            &:before {
-              color: $color-green;
-              content: '\f005\f005\f005\f005\f005';
-              top: 0px;
-              left: 0px;
-              position: absolute;
-            }
+          --percent: calc(var(--rating) / 5 * 100%);
+  
+          display: inline-block;
+          font-size: 2rem;
+          line-height: 1;
+          
+          &::before {
+            content: '★★★★★';
+            letter-spacing: 3px;
+            background: linear-gradient(90deg, $color-green var(--percent), $color-gray var(--percent));
+            background-clip: text;
+            -webkit-text-fill-color: transparent;
           }
         }
         .reviewNameDate {

--- a/src/components/Reviews/Reviews.module.scss
+++ b/src/components/Reviews/Reviews.module.scss
@@ -31,6 +31,8 @@
         margin-right: 0;
         .starRating {
           --percent: calc(var(--rating) / 5 * 100%);
+          overflow: hidden;
+          position: relative;
   
           display: inline-block;
           font-size: 2rem;
@@ -42,6 +44,23 @@
             background: linear-gradient(90deg, $color-green var(--percent), $color-gray var(--percent));
             background-clip: text;
             -webkit-text-fill-color: transparent;
+          }
+          span {
+            overflow: hidden;
+            float: left;
+            top: 0;
+            left: 0;
+            position: absolute;
+            padding-top: 1.5em;
+            color: $primary-color;
+            &:before {
+              color: $color-green;
+              content: '★★★★★';
+              letter-spacing: 3px;
+              top: 0px;
+              left: 0px;
+              position: absolute;
+            }
           }
         }
         .reviewNameDate {

--- a/src/components/SearchResults/SearchResults.module.scss
+++ b/src/components/SearchResults/SearchResults.module.scss
@@ -65,6 +65,7 @@ $color-grey: #777;
     }
     .productImage {
       width: 100%;
+      height: auto;
     }
     .productImageContainer {
       position: relative;

--- a/src/components/Socials/Socials.js
+++ b/src/components/Socials/Socials.js
@@ -11,6 +11,7 @@ const Socials = () => {
           className={styles.socialIcon}
           alt={icon.alt}
           src={icon.src}
+          loading='lazy'
         />
       ))}
     </div>

--- a/src/styles/_ProductSummary.scss
+++ b/src/styles/_ProductSummary.scss
@@ -24,6 +24,7 @@
   }
   .productImage {
     width: 80%;
+    height: auto;
   }
   .productImageContainer {
     position: relative;

--- a/src/styles/pages/_Shop.module.scss
+++ b/src/styles/pages/_Shop.module.scss
@@ -43,6 +43,7 @@
     }
     .productImage {
       width: 100%;
+      height: auto;
     }
     .productImageContainer {
       position: relative;

--- a/src/wp-templates/product.js
+++ b/src/wp-templates/product.js
@@ -30,8 +30,6 @@ import * as MENUS from '@constants/menus';
 import useAtlasEcom from '../hooks/useAtlasEcom';
 import classNames from 'classnames';
 import styles from '@styles/pages/_Product.module.scss';
-import 'slick-carousel/slick/slick.css';
-import 'slick-carousel/slick/slick-theme.css';
 
 const cx = classNames.bind(styles);
 


### PR DESCRIPTION
## Overview 
This is a couple of changes that overall bumps on average 6-8 performance points in lighthouse mobile score:
- removed fontawesome for rating (less ~ 20kb of gzipped styles), it looks much worse, this change gives 2-4 points (I'm okay with rolling back this change if we feel it's not giving us that much value)

| before | after |
|---|---|
| ![Screenshot 2023-01-25 at 14 32 04](https://user-images.githubusercontent.com/91472483/214577370-32ddec34-5603-4cd0-88f6-c8bc2955c08f.png) | ![Screenshot 2023-01-25 at 14 31 55](https://user-images.githubusercontent.com/91472483/214577364-cf0105e0-feca-49bf-ad9a-df45f90269ac.png) |

- added lazyloads to images where possible
- lazyloaded client side modules (gallery)
- minor style changes to work with https://github.com/wpengine/atlas-commerce-blocks/pull/12 

## Result
![Screenshot 2023-01-25 at 14 40 27](https://user-images.githubusercontent.com/91472483/214578410-a415f232-c81a-45d5-b6d1-0120ba167d33.png)


Overall this PR and the one above gets us ~85 performance score. Removing logo and hero images completely gives us 98 (that means: eventually these images are blocking us, and there is poor chance we can go above without affecting hero block, ie adding another field for mobile image)

----

## Note
This is our score when hero + logo are removed:

![Screenshot 2023-01-25 at 14 00 02](https://user-images.githubusercontent.com/91472483/214578191-7ca2ab9b-892c-4f5f-b8a7-b60d87ceee24.png)
