### PR TITLE
fix: align nav and cart

### DIFF
--- a/src/components/NavigationMenu/NavigationMenu.module.scss
+++ b/src/components/NavigationMenu/NavigationMenu.module.scss
@@ -23,7 +23,7 @@
   flex-wrap: wrap;
   justify-content: center;
   padding: 0;
-  margin: 1rem 0;
+  margin-bottom: 1rem;
   position: relative;
   gap: 0.5rem;
 


### PR DESCRIPTION
### Description 

This change was reverted recently. Aligning the menu items in the nav with the cart on the right. 

**Before** 
<img width="1245" alt="Screenshot 2023-01-30 at 14 21 12" src="https://user-images.githubusercontent.com/48026075/215504830-b6a34d3d-3db5-4b46-8473-401b57afac4e.png">

**After** 
<img width="1232" alt="Screenshot 2023-01-30 at 14 21 25" src="https://user-images.githubusercontent.com/48026075/215505021-843be0dd-918a-4913-b417-bc5e8d73e0d8.png">



