### PR TITLE
style: remove fit-content

### DIFF
--- a/src/components/Socials/Socials.module.scss
+++ b/src/components/Socials/Socials.module.scss
@@ -1,7 +1,7 @@
 @import '@styles/Variables';
 
 .socials {
-  display: grid; 
+  display: grid;
   grid-auto-flow: row;
   grid-auto-columns: 1fr;
   grid-auto-rows: 1fr;
@@ -16,6 +16,5 @@
   .socialIcon {
     height: 56px;
     justify-self: center;
-    width: fit-content;
   }
 }


### PR DESCRIPTION
### Description 

Logos are skewed on **Firefox** & **Safari** - `width: fit-content` isnt supported. 

### Screenshots

<img width="1066" alt="Screenshot 2023-01-31 at 20 24 45" src="https://user-images.githubusercontent.com/48026075/215875482-06bc6c1a-06a4-4b0a-9b57-4f677016455f.png">
