### PR TITLE
fix: add nullish coalescing to map method on reviews

### DIFF
--- a/src/components/Reviews/Reviews.js
+++ b/src/components/Reviews/Reviews.js
@@ -15,7 +15,7 @@ const Reviews = ({ reviews, product }) => {
             {reviews?.length ?? 0} review{reviews?.length === 1 ? '' : 's'} for{' '}
             <br /> {product?.name}
           </h3>
-          {reviews?.map((review) => (
+          {reviews?.map?.((review) => (
             <Review
               review={review}
               styles={styles}


### PR DESCRIPTION
### Description 

I was getting an error on localhost when accessing product pages when there were no `Reviews`. 
The nullish coalescing operator `?` needed to be added to the `map` method in the `Reviews.js `component. 

### Testing 

Confirmed that when `?` is added to `map` the error shown below does not occur while running a local dev server or local build

### Screenshots 

<img width="2153" alt="Screenshot 2023-02-08 at 18 05 20" src="https://user-images.githubusercontent.com/48026075/217619363-208f1a41-838d-43b8-943f-f107c0680ee3.png">
